### PR TITLE
fix(products): parse featureBenefit as []string

### DIFF
--- a/pkg/category_structs.go
+++ b/pkg/category_structs.go
@@ -98,7 +98,7 @@ type ProductDetail struct {
 	// Description is the product description
 	Description string `json:"description"`
 	// FeatureBenefit contains marketing benefits
-	FeatureBenefit string `json:"featureBenefit"`
+	FeatureBenefit []string `json:"featureBenefit"`
 	// TradeItemMarketingMessage contains marketing text
 	TradeItemMarketingMessage string `json:"tradeItemMarketingMessage"`
 	// QSCertificationMark indicates QS certification

--- a/pkg/category_structs_test.go
+++ b/pkg/category_structs_test.go
@@ -1,0 +1,47 @@
+package rewerse
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProductDetailFeatureBenefitNullUnmarshal(t *testing.T) {
+	payload := []byte(`{"data":{"product":[{"productId":"1","title":"Test","featureBenefit":null}]}}`)
+
+	var res productDetailResponse
+	if err := json.Unmarshal(payload, &res); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if len(res.Data.Product) != 1 {
+		t.Fatalf("expected 1 product, got %d", len(res.Data.Product))
+	}
+
+	if res.Data.Product[0].FeatureBenefit != nil {
+		t.Fatalf("expected nil featureBenefit for null input, got %#v", res.Data.Product[0].FeatureBenefit)
+	}
+}
+
+func TestProductDetailFeatureBenefitArrayUnmarshal(t *testing.T) {
+	payload := []byte(`{"data":{"product":[{"productId":"1","title":"Test","featureBenefit":["A","B"]}]}}`)
+
+	var res productDetailResponse
+	if err := json.Unmarshal(payload, &res); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	got := res.Data.Product[0].FeatureBenefit
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("unexpected featureBenefit values: %#v", got)
+	}
+}
+
+func TestProductDetailFeatureBenefitStringFailsUnmarshal(t *testing.T) {
+	payload := []byte(`{"data":{"product":[{"productId":"1","title":"Test","featureBenefit":"legacy"}]}}`)
+
+	var res productDetailResponse
+	err := json.Unmarshal(payload, &res)
+	if err == nil {
+		t.Fatal("expected unmarshal error for string featureBenefit, got nil")
+	}
+}


### PR DESCRIPTION
The product details endpoint returns featureBenefit as an array (or null), but we were decoding it as a string. This caused products details calls to fail for valid API responses. This change updates ProductDetail.featureBenefit to []string and adds tests for null, array, and invalid string input to prevent regressions.