### PR TITLE
Handling rewe bonus

### DIFF
--- a/pkg/discounts.go
+++ b/pkg/discounts.go
@@ -84,6 +84,7 @@ func GetDiscounts(marketID string) (ds Discounts, err error) {
 				Subtitle:        rawOffer.Subtitle,
 				Images:          rawOffer.Images,
 				PriceRaw:        rawOffer.PriceData.Price,
+				LoyaltyBonus:    parseLoyaltyBonus(rawOffer.LoyaltyBonus),
 				NutriScore:      rawOffer.Detail.NutriScore,
 				ArticleNo:       rawOffer.RawValues.Nan,
 				ProductCategory: rawOffer.RawValues.CategoryTitle,
@@ -129,4 +130,19 @@ func GetDiscounts(marketID string) (ds Discounts, err error) {
 	}
 
 	return
+}
+
+func parseLoyaltyBonus(raw *RawLoyaltyBonus) *LoyaltyBonus {
+	if raw == nil || raw.BonusValue == 0 {
+		return nil
+	}
+
+	lb := &LoyaltyBonus{BonusType: raw.BonusType}
+	switch strings.ToLower(raw.BonusType) {
+	case "cent":
+		lb.BonusValue = float64(raw.BonusValue) / 100
+	default:
+		lb.BonusValue = float64(raw.BonusValue)
+	}
+	return lb
 }

--- a/pkg/discounts_struct.go
+++ b/pkg/discounts_struct.go
@@ -85,8 +85,8 @@ type RawOffer struct {
 		// RegularPrice is the original price or a label like "Knaller"
 		RegularPrice string `json:"regularPrice"`
 	} `json:"priceData"`
-	// LoyaltyBonus contains bonus points info if applicable
-	LoyaltyBonus any `json:"loyaltyBonus"`
+	// LoyaltyBonus contains REWE bonus cashback info if applicable
+	LoyaltyBonus *RawLoyaltyBonus `json:"loyaltyBonus"`
 	// Stock contains availability info
 	Stock any `json:"stock"`
 	// Detail contains additional product information
@@ -114,6 +114,14 @@ type RawOffer struct {
 		// Nan is the article number (German: Artikelnummer): "7772669"
 		Nan string `json:"nan"`
 	} `json:"rawValues"`
+}
+
+// RawLoyaltyBonus is the REWE bonus program cashback on an offer.
+type RawLoyaltyBonus struct {
+	// BonusType is the unit of bonusValue, typically "cent"
+	BonusType string `json:"bonusType"`
+	// BonusValue is the bonus amount in the type's unit (e.g. 60 = 60 cent)
+	BonusValue int `json:"bonusValue"`
 }
 
 // Discounts is the struct that holds cleaned up discount data.
@@ -155,7 +163,7 @@ func (d Discounts) String() string {
 		sb.WriteString(cat.Title)
 		sb.WriteByte('\n')
 		for _, offer := range cat.Offers {
-			sb.WriteString(fmt.Sprintf("\t%s, %.2f€\n", offer.Title, offer.Price))
+			sb.WriteString(fmt.Sprintf("\t%s\n", offer.formatPriceLine()))
 		}
 	}
 	return sb.String()
@@ -181,8 +189,36 @@ type Discount struct {
 	// if true, Price is 0.0 due to parse failure, not because item is free.
 	Price           float64 `json:"price"`
 	PriceParseFail  bool    `json:"priceParseFail"`
-	Manufacturer    string  `json:"manufacturer"`
-	ArticleNo       string  `json:"articleNo"`
-	NutriScore      string  `json:"nutriScore"`
-	ProductCategory string  `json:"productCategory"`
+	// LoyaltyBonus is REWE bonus cashback when the offer participates in the bonus program.
+	LoyaltyBonus *LoyaltyBonus `json:"loyaltyBonus,omitempty"`
+	Manufacturer string        `json:"manufacturer"`
+	ArticleNo    string        `json:"articleNo"`
+	NutriScore   string        `json:"nutriScore"`
+	ProductCategory string     `json:"productCategory"`
+}
+
+// LoyaltyBonus is parsed REWE bonus cashback on a discount.
+type LoyaltyBonus struct {
+	// BonusType is the unit of the raw API value, typically "cent"
+	BonusType string `json:"bonusType"`
+	// BonusValue is the bonus in euros (e.g. 0.60 for 60 cent)
+	BonusValue float64 `json:"bonusValue"`
+}
+
+func (d Discount) formatPriceLine() string {
+	hasPrice := d.Price > 0
+	hasBonus := d.LoyaltyBonus != nil && d.LoyaltyBonus.BonusValue > 0
+
+	switch {
+	case hasPrice && hasBonus:
+		return fmt.Sprintf("%s, %.2f€ (+%.2f€ Bonus)", d.Title, d.Price, d.LoyaltyBonus.BonusValue)
+	case hasPrice:
+		return fmt.Sprintf("%s, %.2f€", d.Title, d.Price)
+	case hasBonus:
+		return fmt.Sprintf("%s, %.2f€ Bonus", d.Title, d.LoyaltyBonus.BonusValue)
+	case d.PriceParseFail && d.PriceRaw != "":
+		return fmt.Sprintf("%s, %s", d.Title, d.PriceRaw)
+	default:
+		return fmt.Sprintf("%s, %.2f€", d.Title, d.Price)
+	}
 }

--- a/pkg/discounts_struct_test.go
+++ b/pkg/discounts_struct_test.go
@@ -48,4 +48,7 @@ func TestRawDiscountsUnmarshal(t *testing.T) {
 	if offer.RawValues.Nan == "" {
 		t.Error("offer nan is empty")
 	}
+	if offer.LoyaltyBonus != nil && offer.LoyaltyBonus.BonusType == "" {
+		t.Error("loyalty bonus type is empty")
+	}
 }

--- a/pkg/discounts_test.go
+++ b/pkg/discounts_test.go
@@ -1,0 +1,147 @@
+package rewerse
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseLoyaltyBonus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		raw   *RawLoyaltyBonus
+		want  *LoyaltyBonus
+	}{
+		{
+			name: "cent bonus",
+			raw:  &RawLoyaltyBonus{BonusType: "cent", BonusValue: 60},
+			want: &LoyaltyBonus{BonusType: "cent", BonusValue: 0.60},
+		},
+		{
+			name: "uppercase cent",
+			raw:  &RawLoyaltyBonus{BonusType: "CENT", BonusValue: 100},
+			want: &LoyaltyBonus{BonusType: "CENT", BonusValue: 1.00},
+		},
+		{
+			name: "nil",
+			raw:  nil,
+			want: nil,
+		},
+		{
+			name: "zero value",
+			raw:  &RawLoyaltyBonus{BonusType: "cent", BonusValue: 0},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseLoyaltyBonus(tt.raw)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want bonus")
+			}
+			if got.BonusType != tt.want.BonusType || got.BonusValue != tt.want.BonusValue {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscountFormatPriceLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    Discount
+		want string
+	}{
+		{
+			name: "shelf price only",
+			d:    Discount{Title: "Haribo", Price: 0.77},
+			want: "Haribo, 0.77€",
+		},
+		{
+			name: "price and bonus",
+			d: Discount{
+				Title:        "Dr. Oetker Pizza",
+				Price:        1.99,
+				LoyaltyBonus: &LoyaltyBonus{BonusType: "cent", BonusValue: 0.10},
+			},
+			want: "Dr. Oetker Pizza, 1.99€ (+0.10€ Bonus)",
+		},
+		{
+			name: "bonus only",
+			d: Discount{
+				Title:        "Dunkle Pflaumen",
+				LoyaltyBonus: &LoyaltyBonus{BonusType: "cent", BonusValue: 0.60},
+			},
+			want: "Dunkle Pflaumen, 0.60€ Bonus",
+		},
+		{
+			name: "parse failure fallback",
+			d: Discount{
+				Title:          "Broken",
+				PriceRaw:       "ab 1,99 €",
+				PriceParseFail: true,
+			},
+			want: "Broken, ab 1,99 €",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.d.formatPriceLine(); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDiscountFromFixture(t *testing.T) {
+	var rd RawDiscounts
+	if err := json.Unmarshal(loadFixture(t, "discounts.json"), &rd); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	var yfood *RawOffer
+	for _, cat := range rd.Data.Offers.Current.Categories {
+		if cat.ID != "rewe-bonus-produkte" {
+			continue
+		}
+		for i := range cat.Offers {
+			if cat.Offers[i].Title == "YFood Trinkmahlzeit" {
+				yfood = &cat.Offers[i]
+				break
+			}
+		}
+	}
+	if yfood == nil {
+		t.Fatal("YFood offer not found in fixture")
+	}
+
+	discount := Discount{
+		Title:        yfood.Title,
+		Price:        3.29,
+		PriceRaw:     yfood.PriceData.Price,
+		LoyaltyBonus: parseLoyaltyBonus(yfood.LoyaltyBonus),
+	}
+
+	if discount.Price != 3.29 {
+		t.Fatalf("price = %v, want 3.29", discount.Price)
+	}
+	if discount.LoyaltyBonus == nil || discount.LoyaltyBonus.BonusValue != 0.30 {
+		t.Fatalf("loyalty bonus = %+v, want 0.30", discount.LoyaltyBonus)
+	}
+	if got := discount.formatPriceLine(); got != "YFood Trinkmahlzeit, 3.29€ (+0.30€ Bonus)" {
+		t.Fatalf("formatPriceLine = %q", got)
+	}
+}


### PR DESCRIPTION
When testing the API I noticed that some prices were being returned as 0 Eur, but on the website they were part of the rewe bonus aktionen.
For example
```
	Dunkle Pflaumen, 0.00€
	Nutella Biscuits, 0.00€

```
With these changes (helped by Cursor) I'm proposing that the so-called `Loyalty Bonus` is displayed, so now whenever there's a rewe bonus aktion we get something like
```
Kochen und Backen
	Knorr Fix Spaghetti Bolognese, 0.49€ (+0.10€ Bonus)
	Ben’s Original Express Reis, 1.49€ (+0.10€ Bonus)
```

Or  when there's no discounted price, but there's rewe bonus
```
	Kinder Kinderini, 1.00€ Bonus
	Dunkle Pflaumen, 0.60€ Bonus
	Nutella Biscuits, 1.00€ Bonus
```

Thank you for such great work on this :D 